### PR TITLE
Implement custom hover solution for persistent dropdown menus

### DIFF
--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -11,15 +11,6 @@ import { useAuth } from "@/hooks/use-auth";
 import { useTenant } from "@/hooks/use-tenant";
 import { getSiteBranding } from "@/lib/api";
 import { defaultSiteBranding, SiteBranding } from "@shared/site_branding";
-import {
-  NavigationMenu,
-  NavigationMenuContent,
-  NavigationMenuItem,
-  NavigationMenuLink,
-  NavigationMenuList,
-  NavigationMenuTrigger,
-  navigationMenuTriggerStyle,
-} from "@/components/ui/navigation-menu";
 import { cn } from "@/lib/utils";
 import progressLogoPath from "@assets/Light Logo.png";
 
@@ -118,40 +109,71 @@ export default function Navbar() {
     return location === href;
   };
 
-  // Function to render nav links with hover dropdown
+  // Function to render nav links with custom hover dropdown
   const renderDesktopDropdown = (group: MenuGroup) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [hoverTimeout, setHoverTimeout] = useState<NodeJS.Timeout | null>(null);
+    
+    useEffect(() => {
+      return () => {
+        if (hoverTimeout) {
+          clearTimeout(hoverTimeout);
+        }
+      };
+    }, [hoverTimeout]);
+    
+    const handleMouseEnter = () => {
+      if (hoverTimeout) {
+        clearTimeout(hoverTimeout);
+        setHoverTimeout(null);
+      }
+      setIsOpen(true);
+    };
+    
+    const handleMouseLeave = () => {
+      const timeout = setTimeout(() => {
+        setIsOpen(false);
+      }, 300); // 300ms delay before closing
+      setHoverTimeout(timeout);
+    };
+    
     return (
-      <NavigationMenuItem key={group.label}>
-        <NavigationMenuTrigger 
-          className={cn(
-            "font-medium text-white hover:text-[#7B3FE4] transition duration-300 outline-none flex items-center bg-transparent hover:bg-transparent focus:bg-transparent data-[active]:bg-transparent data-[state=open]:bg-transparent",
-            "group inline-flex h-auto w-max items-center justify-center px-4 py-2 text-sm"
-          )}
+      <div 
+        key={group.label} 
+        className="relative"
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        <button
+          className="font-medium text-white hover:text-[#7B3FE4] transition duration-300 outline-none flex items-center px-4 py-2"
         >
-          {group.label}
-        </NavigationMenuTrigger>
-        <NavigationMenuContent className="min-w-[300px] bg-zinc-900 border-zinc-700 p-4">
-          <div className="grid gap-3">
-            <div className="text-white font-semibold text-sm mb-2 px-2">{group.label}</div>
-            <div className="grid gap-1">
-              {group.items.map((item) => (
-                <NavigationMenuLink key={item.label} asChild>
+          {group.label} 
+          <ChevronDown className={`h-4 w-4 ml-1 opacity-70 transition-transform duration-300 ${isOpen ? 'rotate-180' : ''}`} />
+        </button>
+        
+        {isOpen && (
+          <div className="absolute left-0 top-full mt-1 min-w-[300px] bg-zinc-900 border border-zinc-700 rounded-md shadow-lg z-50">
+            <div className="p-4">
+              <div className="text-white font-semibold text-sm mb-2 px-2">{group.label}</div>
+              <div className="grid gap-1">
+                {group.items.map((item) => (
                   <Link
+                    key={item.label}
                     href={item.href}
                     className={cn(
-                      "flex items-center select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-zinc-800 hover:text-[#7B3FE4] focus:bg-zinc-800 focus:text-[#7B3FE4]",
+                      "flex items-center rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-zinc-800 hover:text-[#7B3FE4] focus:bg-zinc-800 focus:text-[#7B3FE4]",
                       isActive(item.href) ? 'text-[#7B3FE4] bg-zinc-800' : 'text-gray-300'
                     )}
                   >
                     <div className="mr-2">{item.icon}</div>
                     <div className="text-sm font-medium">{item.label}</div>
                   </Link>
-                </NavigationMenuLink>
-              ))}
+                ))}
+              </div>
             </div>
           </div>
-        </NavigationMenuContent>
-      </NavigationMenuItem>
+        )}
+      </div>
     );
   };
 
@@ -192,12 +214,8 @@ export default function Navbar() {
         </div>
 
         {/* Desktop Menu - Public-facing menu only */}
-        <div className="hidden lg:flex items-center">
-          <NavigationMenu delayDuration={200}>
-            <NavigationMenuList className="space-x-2">
-              {publicMenuGroups.map(renderDesktopDropdown)}
-            </NavigationMenuList>
-          </NavigationMenu>
+        <div className="hidden lg:flex items-center space-x-2">
+          {publicMenuGroups.map(renderDesktopDropdown)}
         </div>
 
         {/* Right side buttons */}


### PR DESCRIPTION
- Replace NavigationMenu with custom hover state management
- Add 300ms delay before closing dropdown menus
- Use manual onMouseEnter/onMouseLeave handlers
- Clear timeouts properly to prevent premature closing
- Add cleanup effect to prevent memory leaks
- Set z-index to 50 for proper layering

This provides more reliable hover behavior where menus stay open while transitioning from trigger to submenu items.

🤖 Generated with [Claude Code](https://claude.ai/code)